### PR TITLE
Allow users to compile builds without flatpak

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,46 @@ Adwaita Manager (AdwCustomizer) is a tool for customizing Libadwaita application
 
 ## Building and Installing
 
-See `next` branch for UI rework and latest commit.
+**[NOTE]** See `next` branch for UI rework and latest commits.
+
+## Requirements:
+- Python 3 `python`
+- PyGObject `python-gobject`
+- Blueprint <code>[blueprint-compiler](https://jwestman.pages.gitlab.gnome.org/blueprint-compiler/setup.html)</code>
+- GTK4 `gtk4`
+- libadwaita (>= 1.2.alpha) `libadwaita`
+- Meson `meson`
+- Ninja `ninja`
+
+## Building from source:
+
+Install required Python libraries:
+```sh
+pip install -r requirements.txt
+pip3 install $(pwd)/monet/material_color_utilities_python-0.1.0-py3-none-any.whl
+```
+
+### Global installation:
+```sh
+git clone https://github.com/AdwCustomizerTeam/AdwCustomizer.git
+cd AdwCustomizer
+meson builddir --prefix=/usr/local
+sudo ninja -C builddir install
+```
+
+### Local build (for testing and development purposes):
+```sh
+git clone https://github.com/AdwCustomizerTeam/AdwCustomizer.git
+cd AdwCustomizer
+meson builddir
+meson configure builddir -Dprefix="$(pwd)/builddir/testdir"
+ninja -C builddir install
+ninja -C builddir run
+```
+
+**[NOTE]** During testing and developement, as a convenience, you can use the `local.sh` script to quickly rebuild local builds.
+
+### Building using flatpak-builder:
 
 1. Open Terminal
 2. Run `git clone https://github.com/AdwCustomizerTeam/AdwCustomizer.git && cd AdwCustomizer`

--- a/local.sh
+++ b/local.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/bash
+
+read -p "Do you want to install Python requirements? (yes, no): " answer
+
+if [[ "$answer" == "yes" ]]; then
+    pip3 install --user -r requirements.txt
+    pip3 install $(pwd)/monet/material_color_utilities_python-0.1.0-py3-none-any.whl
+elif [[ "$answer" == "no" ]]; then
+    echo "Skipping requirements installation"
+fi
+
+echo "Cleaning builddir directory"
+rm -r builddir
+
+echo "Rebuilding"
+meson builddir
+meson configure builddir -Dprefix="$(pwd)/builddir/testdir"
+ninja -C builddir install
+
+echo "Running"
+ninja -C builddir run

--- a/meson.build
+++ b/meson.build
@@ -6,13 +6,13 @@ project('adwcustomizer',
                    ],
 )
 
-dependency('glib-2.0')
-dependency('pygobject-3.0')
-dependency('libadwaita-1')
-
 i18n = import('i18n')
-
 gnome = import('gnome')
+
+dependency('glib-2.0')
+dependency('gtk4', version: '>= 4.5.0')
+dependency('libadwaita-1', version: '>= 1.2.alpha')
+dependency('pygobject-3.0', version: '>= 3.42.0')
 
 subdir('data')
 subdir('src')

--- a/src/adwcustomizer.in
+++ b/src/adwcustomizer.in
@@ -24,15 +24,25 @@ import signal
 import locale
 import gettext
 
-VERSION = '@VERSION@'
 pkgdatadir = '@pkgdatadir@'
 localedir = '@localedir@'
+version = '@VERSION@'
+
+builddir = os.environ.get('MESON_BUILD_ROOT')
+
+if builddir:
+    sys.dont_write_bytecode = True
+    sys.path.insert(1, os.environ['MESON_SOURCE_ROOT'])
+    data_dir = os.path.join(builddir, '@DATA_DIR@')
+    os.putenv('XDG_DATA_DIRS', '%s:%s' % (data_dir, os.getenv('XDG_DATA_DIRS', '/usr/local/share/:/usr/share/')))
 
 sys.path.insert(1, pkgdatadir)
 signal.signal(signal.SIGINT, signal.SIG_DFL)
+gettext.install('adwcustomizer', localedir)
+
 locale.bindtextdomain('adwcustomizer', localedir)
 locale.textdomain('adwcustomizer')
-gettext.install('adwcustomizer', localedir)
+
 
 if __name__ == '__main__':
     import gi
@@ -43,8 +53,9 @@ if __name__ == '__main__':
     gi.require_version('XdpGtk4', '1.0')
 
     from gi.repository import Gio
-    resource = Gio.Resource.load(os.path.join(pkgdatadir, 'adwcustomizer.gresource'))
+    resource = Gio.Resource.load(
+        os.path.join(pkgdatadir, 'adwcustomizer.gresource'))
     resource._register()
 
     from adwcustomizer import main
-    sys.exit(main.main(VERSION))
+    sys.exit(main.main(version))

--- a/src/meson.build
+++ b/src/meson.build
@@ -29,6 +29,7 @@ python = import('python')
 conf = configuration_data()
 conf.set('PYTHON', python.find_installation('python3').full_path())
 conf.set('VERSION', meson.project_version())
+conf.set('DATA_DIR', join_paths(get_option('prefix'), get_option('datadir')))
 conf.set('localedir', join_paths(get_option('prefix'), get_option('localedir')))
 conf.set('pkgdatadir', pkgdatadir)
 
@@ -49,6 +50,12 @@ configure_file(
            'version': meson.project_version(),
         'build_type': get_option('buildtype'),
   }),
+)
+
+launcher = join_paths(meson.project_build_root(), 'src', meson.project_name())
+
+run_target('run',
+  command: [launcher]
 )
 
 adwcustomizer_sources = [


### PR DESCRIPTION
This PR provides a way for developers and distro packagers to compile and ship AdwCustomizer without a need to install flatpak.

Btw, where can I find a source code for `material_color_utilities_python` library? I couldn't find it on PyPI, and I would be interested to maybe improve it, as its speed for now is atrocious.